### PR TITLE
Feature/better repr

### DIFF
--- a/orator/orm/model.py
+++ b/orator/orm/model.py
@@ -3013,4 +3013,7 @@ class Model(metaclass=MetaModel):
         self.set_exists(state['exists'])
 
     def __repr__(self):
-        return '{cls}({attributes})'.format(cls=self.__class__.__name__, attributes=self.attributes_to_dict())
+        return '{cls}({attributes})'.format(
+            cls=self.__class__.__name__,
+            attributes=self.attributes_to_dict()
+        )

--- a/orator/orm/model.py
+++ b/orator/orm/model.py
@@ -3011,3 +3011,6 @@ class Model(metaclass=MetaModel):
         self.set_raw_attributes(state['attributes'], True)
         self.set_relations(state['relations'])
         self.set_exists(state['exists'])
+
+    def __repr__(self):
+        return '{cls}({attributes})'.format(cls=self.__class__.__name__, attributes=self.attributes_to_dict())


### PR DESCRIPTION
We are focusing the attributes of a data model rather than the default object address.

Using `attributes_to_dict` is quite useful for interpretion(or logging, or sentry error handler), and it's safe when you assign `__hidden__` or `__visible__` correctly.

before:

```python interpreter
>>> Parent.first()
<app.models.account.Parent object at 0x7f6870e6ae48>
```

after:

```python interpreter
>>> Parent.first()
Parent({'id': 1, 'family_id': 82552789, 'role': 2, 'avatar_name': '', 'nickname': 'iCell', 'created_at': '2018-01-30T10:06:32.034390', 'updated_at': '2018-01-30T10:06:32.034390', 'avatar_urls': ['https://media-image1.baydn.com/storage_media_image/bwtwfv/6d9e95be358f877511d2cd04fc77ee12.9823dc46699d2966b17cc8cac0a72aca.png']})
```
